### PR TITLE
Allow solutions with different first letters

### DIFF
--- a/main.go
+++ b/main.go
@@ -64,7 +64,7 @@ func main() {
 		}
 
 		progressed := false
-		for j := len(indices) - 1; j > 0; j-- {
+		for j := len(indices) - 1; j >= 0; j-- {
 			if indices[j]+1 < len(spec.letters[j]) {
 				indices[j]++
 				for k := j + 1; k < len(indices); k++ {


### PR DESCRIPTION
I found this bug while I was rewriting another part to make the app read the letter groups from command line arguments.
The loop didn't seem to have a chance to iterate over the first letter group.