### PR TITLE
Changing puzzle input method to one that doesn't require recompiling

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,11 @@ Dictionary sourced from <https://github.com/dwyl/english-words>
 
 ### Usage
 
-Modify the `spec` variable at the start of the main function, then run:
+Build a binary and then provide it with the groups of letters as arguments:
 
 ```bash
-go run main.go
+go build
+./typecheat rsalp eihon wxast tyrdi pioe v gnyde
 ```
 
 It should print all the combinations that are words.

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"fmt"
 	"log"
 	"os"
 	"time"
@@ -15,15 +16,18 @@ type Spec struct {
 
 func main() {
 	spec := Spec{
-		letters: []Letter{
-			[]string{"r", "s", "a", "l", "p"},
-			[]string{"e", "i", "h", "o", "n"},
-			[]string{"w", "x", "a", "s", "t"},
-			[]string{"t", "y", "r", "d", "i"},
-			[]string{"p", "i", "o", "e"},
-			[]string{"v"},
-			[]string{"g", "n", "y", "d", "e"},
-		},
+		letters: []Letter{},
+	}
+	if len(os.Args[1:]) < 1 {
+		fmt.Fprintf(os.Stderr, "Place letter groups as subsequent arguments, like this:\n\t%s rsalp eihon wxast tyrdi pioe v gnyde\n", os.Args[0])
+		os.Exit(1)
+	}
+	for _, letter := range os.Args[1:] {
+		l := []string{}
+		for _, char := range letter {
+			l = append(l, string(char))
+		}
+		spec.letters = append(spec.letters, l)
 	}
 
 	t1 := time.Now()


### PR DESCRIPTION
Letter groups are now input as commandline arguments